### PR TITLE
Exception Handler Helper and messages broken encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ See [compatibility docs](docs/compatibility.md) for details about backward compa
 
 * @dev
    * TestingHelpers trait's `validateResponseStructure()` method is now public
+   * [RB-65] Exception Handler Helper now deals with messages using non-UTF8 or broken encoding 
 
 * v4.0.0 (2017-04-10)
    * **BACKWARD INCOMPATIBILE CHANGES**

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ then then feel free to donate to the project. Send some Bitcoins (BTC) to `1Lbfb
  * API chaining/cascading support,
  * Includes traits to help [unit testing your API code](docs/testing.md),
  * Provides own [exception handler helper](docs/exceptions.md) to ensure your API stays consumable even in case of unexpected,
- * No extra dependencies.
+ * No extra mandatory dependencies.
 
 ----
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -366,13 +366,15 @@ to handle them yourself by calling `Lang::get()` manually first and pass the res
 
 ## Requirements ##
 
-There're no special requirements. Once you fulfill Laravel's requirements you are all good. Minimum
-versions `ResponseBuilder` is tested against are:
+Minimum requirements:
 
-  * PHP 5.5+
-  * Laravel 5.1.45+
+  * PHP 5.5
+  * Laravel 5.1.45
 
-all newer versions of PHP and Laravel are also supported out of the box.
+The following PHP extensions are optional but strongly recommended: 
+
+   * iconv
+   * mb_string
 
 ----
 

--- a/src/ExceptionHandlerHelper.php
+++ b/src/ExceptionHandlerHelper.php
@@ -166,6 +166,18 @@ class ExceptionHandlerHelper
 		// let's build error message
 		$error_message = '';
 		$ex_message = trim($exception->getMessage());
+
+		// ensure we won't fail due to exception incorect encoding
+		if (!mb_check_encoding($ex_message, 'UTF-8')) {
+			// let's check there's iconv and mb_string available
+			if (function_exists('iconv') && function_exists('mb_detec_encoding')) {
+				$ex_message = iconv(mb_detect_encoding($ex_message, mb_detect_order(), true), 'UTF-8', $ex_message);
+			} else {
+				// lame fallback, in case there's no iconv/mb_string installed
+				$ex_message = htmlspecialchars_decode(htmlspecialchars($ex_message, ENT_SUBSTITUTE, 'UTF-8'));
+			}
+		}
+
 		if (Config::get('response_builder.exception_handler.use_exception_message_first', true)) {
 			if ($ex_message === '') {
 				$ex_message = get_class($exception);


### PR DESCRIPTION
Exception Handler Helper now deals with messages using non-UTF8 or broken encoding.

Closes #65 