### PR TITLE
[WIP] Made localization optional

### DIFF
--- a/config/response_builder.php
+++ b/config/response_builder.php
@@ -22,10 +22,14 @@ return [
 
 	/*
 	|-----------------------------------------------------------------------------------------------------------
-	| Error code to message mapping
-	|-----------------------------------------------------------------------------------------------------------
-	|
-	*/
+	| Localization settings
+    |-----------------------------------------------------------------------------------------------------------
+    |
+    | The following array maps error codes to message keys. It is used by the package to provide
+    | a comprehensive message based on an error code.
+    |
+    */
+    'use_localization'  => true,
 	'map'               => [
 
 	],

--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -51,6 +51,7 @@ class ResponseBuilder
 	public const CONF_KEY_DEBUG_EX_TRACE_ENABLED = 'response_builder.debug.exception_handler.trace_enabled';
 	public const CONF_KEY_DEBUG_EX_TRACE_KEY     = 'response_builder.debug.exception_handler.trace_key';
 	public const CONF_KEY_MAP                    = 'response_builder.map';
+	public const CONF_USE_LOCALIZATION_KEY       = 'response_builder.use_localization';
 	public const CONF_KEY_ENCODING_OPTIONS       = 'response_builder.encoding_options';
 	public const CONF_KEY_CLASSES                = 'response_builder.classes';
 	public const CONF_KEY_MIN_CODE               = 'response_builder.min_code';
@@ -406,7 +407,7 @@ class ResponseBuilder
 			}
 
 			$lang_args = $lang_args ?? ['api_code' => $message_or_api_code];
-			$message_or_api_code = \Lang::get($key, $lang_args);
+			$message_or_api_code = Config::get(static::CONF_USE_LOCALIZATION_KEY, true) ? \Lang::get($key, $lang_args) : $key;
 		}
 
 		return Response::json(


### PR DESCRIPTION
This is a wonderful package, but sometimes we don't want localization. If, for instance, localization is managed differently on some front-end, then we may not want to received a localized string when consuming an API. 

With those changes, I propose to add an `use_localization` option in the configuration, which would simply make the response builder not translate the localization.

I did not add test coverage since the localization is too deeply implemented in the package. I think this feature would require more changes than what I made. 

What do you think?