### PR TITLE
Release v6.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - LARAVEL_VERSION="6.0"
   - LARAVEL_VERSION="6.2"
   - LARAVEL_VERSION="6.3"
+  - LARAVEL_VERSION="6.4"
 
 #matrix:
 #  exclude:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ See [compatibility docs](docs/compatibility.md) for details about backward compa
 
 ## CHANGE LOG ##
 
-* @dev
+* v6.2.3 (2019-10-31)
    * Added Laravel 6.4 to Travis-CI unit tests.
    * Corrected example in "Manipulating Response Object" docs.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ See [compatibility docs](docs/compatibility.md) for details about backward compa
 
 ## CHANGE LOG ##
 
+* @dev
+   * Added Laravel 6.4 to Travis-CI unit tests.
+
 * v6.2.2 (2019-10-22)
    * Squashed multiple typographic errors in the documentation files.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ See [compatibility docs](docs/compatibility.md) for details about backward compa
 
 * @dev
    * Added Laravel 6.4 to Travis-CI unit tests.
+   * Corrected example in "Manipulating Response Object" docs.
 
 * v6.2.2 (2019-10-22)
    * Squashed multiple typographic errors in the documentation files.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "marcin-orlowski/laravel-api-response-builder",
   "description": "Helps building nice, normalized and easy to consume Laravel REST API.",
   "homepage": "https://github.com/MarcinOrlowski/laravel-api-response-builder",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "keywords": [
     "laravel",
     "json",

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -544,9 +544,7 @@ class ApiCode {
 ## Manipulating Response Object ##
 
  If you need to return more fields in response object you can simply extend `ResponseBuilder` class
- and override `buildResponse()` method:
-
-    protected static function buildResponse($code, $message, $data = null);
+ and override `buildResponse()` method.
 
  For example, you want to get rid of `locale` field and add server time and timezone to returned
  responses. First, create `MyResponseBuilder.php` file in `app/` folder (both location and class
@@ -561,7 +559,8 @@ namespace App;
 
 class MyResponseBuilder extends MarcinOrlowski\ResponseBuilder\ResponseBuilder
 {
-   protected static function buildResponse($code, $message, $data = null)
+   protected static function buildResponse(bool $success, int $api_code, string $message,
+                                           $data = null, array $debug_data = null): array
    {
       // tell ResponseBuilder to do all the heavy lifting first
       $response = parent::buildResponse($code, $message, $data);

--- a/travis/composer-6.4.json
+++ b/travis/composer-6.4.json
@@ -1,0 +1,24 @@
+{
+  "name": "marcin-orlowski/laravel-api-response-builder",
+  "require": {
+    "php": ">=7.2"
+  },
+  "autoload": {
+    "psr-4": {
+      "MarcinOrlowski\\ResponseBuilder\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "MarcinOrlowski\\ResponseBuilder\\": "src",
+      "MarcinOrlowski\\ResponseBuilder\\Tests\\": "tests"
+    }
+  },
+  "require-dev": {
+    "orchestra/testbench": "^4.0",
+    "laravel/framework": "^6.4",
+    "phpunit/phpunit": "^8.0",
+    "phpunit/php-code-coverage": "^7.0",
+    "codacy/coverage": "^1.0"
+  }
+}


### PR DESCRIPTION
   * Added Laravel 6.4 to Travis-CI unit tests.
   * Corrected example in "Manipulating Response Object" docs.