### PR TITLE
Corrected JsonSerializableConverter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ See [compatibility docs](docs/compatibility.md) for details about backward compa
 
 ## CHANGE LOG ##
 
+* @dev
+   * [RB-141] Fixed `JsonSerializableConverter` to deal non-string `jsonSerialize()` return data (reported by Jonatan Fekete) 
+
 * v7.1.1 (2020-07-11)
    * Added more tests.
    * Updated dependencies.

--- a/src/Converters/ArrayableConverter.php
+++ b/src/Converters/ArrayableConverter.php
@@ -28,7 +28,7 @@ class ArrayableConverter implements ConverterContract
      *
      * @return array
      */
-    public function convert($obj, array /** @scrutinizer ignore-unused */ $config): array
+    public function convert($obj, /** @scrutinizer ignore-unused */ array $config): array
     {
         Validator::assertInstanceOf('obj', $obj, Arrayable::class);
 

--- a/src/Converters/JsonSerializableConverter.php
+++ b/src/Converters/JsonSerializableConverter.php
@@ -28,7 +28,7 @@ class JsonSerializableConverter implements ConverterContract
 	 *
 	 * @return array
 	 */
-	public function convert($obj, array /** @scrutinizer ignore-unused */ $config): array
+	public function convert($obj, /** @scrutinizer ignore-unused */ array $config): array
 	{
 		Validator::assertInstanceOf('obj', $obj, \JsonSerializable::class);
 

--- a/src/Converters/JsonSerializableConverter.php
+++ b/src/Converters/JsonSerializableConverter.php
@@ -19,19 +19,19 @@ use MarcinOrlowski\ResponseBuilder\Validator;
 
 class JsonSerializableConverter implements ConverterContract
 {
-    /**
-     * Returns array representation of the object implementing \JsonSerializable interface.
-     *
-     * @param \JsonSerializable $obj    Object to be converted
-     * @param array             $config Converter config array to be used for this object (based on exact class
-     *                                  name match or inheritance).
-     *
-     * @return array
-     */
-    public function convert($obj, array /** @scrutinizer ignore-unused */ $config): array
-    {
-        Validator::assertInstanceOf('obj', $obj, \JsonSerializable::class);
+	/**
+	 * Returns array representation of the object implementing \JsonSerializable interface.
+	 *
+	 * @param \JsonSerializable $obj    Object to be converted
+	 * @param array             $config Converter config array to be used for this object (based on exact class
+	 *                                  name match or inheritance).
+	 *
+	 * @return array
+	 */
+	public function convert($obj, array /** @scrutinizer ignore-unused */ $config): array
+	{
+		Validator::assertInstanceOf('obj', $obj, \JsonSerializable::class);
 
-        return ['val' => json_decode($obj->jsonSerialize(), true)];
-    }
+		return ['val' => json_decode(json_encode($obj->jsonSerialize()), true)];
+	}
 }

--- a/src/Converters/ToArrayConverter.php
+++ b/src/Converters/ToArrayConverter.php
@@ -28,7 +28,7 @@ class ToArrayConverter implements ConverterContract
      *
      * @return array
      */
-    public function convert($obj, array /** @scrutinizer ignore-unused */ $config): array
+    public function convert($obj, /** @scrutinizer ignore-unused */ array $config): array
     {
         Validator::assertIsObject('obj', $obj);
 

--- a/tests/Models/TestModelJsonSerializable.php
+++ b/tests/Models/TestModelJsonSerializable.php
@@ -33,8 +33,8 @@ class TestModelJsonSerializable implements \JsonSerializable
         return $this->val;
     }
 
-    public function jsonSerialize(): string
+    public function jsonSerialize()
     {
-        return json_encode($this->val);
+        return $this->val;
     }
 }

--- a/tests/tests/Converter/DefaultConfigTest.php
+++ b/tests/tests/Converter/DefaultConfigTest.php
@@ -54,20 +54,27 @@ class DefaultConfigTest extends TestCase
      */
     public function testJsonSerializable(): void
     {
-        // GIVEN JsonSerializable class object
-        $obj_val = $this->getRandomString('obj_val');
-        $obj = new TestModelJsonSerializable($obj_val);
+    	$values = [
+		    $this->getRandomString('obj_val'),
+		    [$this->getRandomString('obj_a'), $this->getRandomString('obj_b')],
+		    mt_rand(),
+    		];
 
-        // HAVING converter with default settings
-        $converter = new Converter();
+    	foreach ($values as $obj_val) {
+	        // GIVEN JsonSerializable class object
+	        $obj = new TestModelJsonSerializable($obj_val);
 
-        // WHEN we try to pass of object of that class
-        $result = $converter->convert($obj);
+	        // HAVING converter with default settings
+	        $converter = new Converter();
 
-        // THEN it should be converted automatically as per configuration
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('val', $result);
-        $this->assertEquals($result['val'], $obj_val);
+	        // WHEN we try to pass of object of that class
+	        $result = $converter->convert($obj);
+
+	        // THEN it should be converted automatically as per configuration
+	        $this->assertIsArray($result);
+	        $this->assertArrayHasKey('val', $result);
+	        $this->assertEquals($obj_val, $result['val']);
+	    }
     }
 
     /**


### PR DESCRIPTION
Fixed `JsonSerializableConverter` to deal non-string `jsonSerialize()` return data. Fixes #141 