### PR TITLE
Fixed RB Alias Errors

### DIFF
--- a/src/ResponseBuilderServiceProvider.php
+++ b/src/ResponseBuilderServiceProvider.php
@@ -22,6 +22,7 @@ namespace MarcinOrlowski\ResponseBuilder;
  */
 
 use Illuminate\Support\ServiceProvider;
+use MarcinOrlowski\ResponseBuilder\ResponseBuilder as RB;
 
 class ResponseBuilderServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
This one is related to issue #162 .

I think this way is more elegant @MarcinOrlowski instead of creating an empty class of `class RB extends ResponseBuilder`
I have tested it, and it works