### PR TITLE
fix converter classes reference on sorting

### DIFF
--- a/src/ResponseBuilderServiceProvider.php
+++ b/src/ResponseBuilderServiceProvider.php
@@ -70,8 +70,8 @@ class ResponseBuilderServiceProvider extends ServiceProvider
 
         $merged_config = Util::mergeConfig($defaults, $config);
 
-        if (\array_key_exists('converter', $merged_config)) {
-            Util::sortArrayByPri($merged_config['converter']);
+        if (isset($merged_config['converter']['classes'])) {
+            Util::sortArrayByPri($merged_config['converter']['classes']);
         }
 
         $this->app['config']->set($key, $merged_config);


### PR DESCRIPTION
Hi again @MarcinOrlowski ! Thank you for the great package.

I noticed the config structure is changed for converter array so I simply made changes to reflect while sorting. The pri parameter are now working after this change.
