### PR TITLE
Release 9.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@ before doing major upgrade!
 
 ## CHANGE LOG ##
 
+* @dev
+   * [RB-175] `Paginator` and `LengthAwarePaginator` support is now included in default converter 
+     configuration (reported by @kcaj-burr) 
+   * Fixed `testConfigClassesMappingEntriesUnwantedConfigKeys()` testing trait not supporting
+     `null` keys in converter config.
+
 * v9.0.3 (2020-10-27)
    * `Validator` type related exceptions must now implement `InvalidTypeExceptionContract`.
    * The `converter` config `key` element now accepts `null` to indicate you want no key to
@@ -33,7 +39,7 @@ before doing major upgrade!
 
 * v8.1.1 (2020-10-15)
    * [RB-155] Fixed `ResponseBuilder` internals preventing exdending class code from
-     being invoked, thus making response object structure manipulation ineffective (reported by krek95).
+     being invoked, thus making response object structure manipulation ineffective (reported by @krek95).
 
 * v8.1.0 (2020-09-17)
    * Added logging (`.env` controllable) for payload Converter to help debugging inproper data conversion.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ before doing major upgrade!
 
 ## CHANGE LOG ##
 
-* @dev
+* v9.1.0 (2020-10-29)
    * [RB-175] `Paginator` and `LengthAwarePaginator` support is now included in default converter 
      configuration (reported by @kcaj-burr) 
    * Fixed `testConfigClassesMappingEntriesUnwantedConfigKeys()` testing trait not supporting

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@ before doing major upgrade!
 
 * v9.0.3 (2020-10-27)
    * `Validator` type related exceptions must now implement `InvalidTypeExceptionContract`.
-   * `converter` config `key` element now accepts `null` to indicate you want no key to be used.
+   * The `converter` config `key` element now accepts `null` to indicate you want no key to
+     be used (patch by Raja)
 
 * v9.0.2 (2020-10-24)
    * Corrected tests to use regular ServiceProvider.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "marcin-orlowski/laravel-api-response-builder",
   "description": "Helps building nice, normalized and easy to consume Laravel REST API.",
   "homepage": "https://github.com/MarcinOrlowski/laravel-api-response-builder",
-  "version": "9.0.3",
+  "version": "9.1.0",
   "keywords": [
     "laravel",
     "json",

--- a/config/response_builder.php
+++ b/config/response_builder.php
@@ -80,6 +80,23 @@ return [
 	        ],
 
 	        /*
+			|-----------------------------------------------------------------------------------------------------------
+			| Paginators converts to objects already, so we do not array wrapping here, hence setting `key` to null
+			|-----------------------------------------------------------------------------------------------------------
+			*/
+
+	        \Illuminate\Pagination\LengthAwarePaginator::class => [
+		        'handler' => \MarcinOrlowski\ResponseBuilder\Converters\ArrayableConverter::class,
+		        'key'     => null,
+		        'pri'     => 0,
+	        ],
+	        \Illuminate\Pagination\Paginator::class => [
+		        'handler' => \MarcinOrlowski\ResponseBuilder\Converters\ArrayableConverter::class,
+		        'key'     => null,
+		        'pri'     => 0,
+	        ],
+
+	        /*
 	        |-----------------------------------------------------------------------------------------------------------
 	        | Generic converters should have lower pri to allow dedicated ones to kick in first when class matches
 	        |-----------------------------------------------------------------------------------------------------------

--- a/docs/config.md
+++ b/docs/config.md
@@ -67,15 +67,15 @@ php artisan vendor:publish
 
 ```php
 'converter' => [
-    \Illuminate\Database\Eloquent\Model::class          => [
+    \Illuminate\Database\Eloquent\Model::class => [
         'handler' => \MarcinOrlowski\ResponseBuilder\Converters\ToArrayConverter::class,
         'key'     => 'items',
-        // 'pri'     => 0,
+        'pri'     => 0,
     ],
-    \Illuminate\Database\Eloquent\Collection::class     => [
-        'handler' => \MarcinOrlowski\ResponseBuilder\Converters\ToArrayConverter::class,
-        'key'     => 'items',
-        // 'pri'     => 0,
+    \Illuminate\Pagination\Paginator::class => [
+        'handler' => \MarcinOrlowski\ResponseBuilder\Converters\ArrayableConverter::class,
+        'key'     => null,
+        'pri'     => 0,
     ],
 ],
 ```

--- a/tests/Traits/ApiCodesTests.php
+++ b/tests/Traits/ApiCodesTests.php
@@ -26,240 +26,248 @@ use MarcinOrlowski\ResponseBuilder\Tests\TestCase;
  */
 trait ApiCodesTests
 {
-    use TestingHelpers;
+	use TestingHelpers;
 
-    /**
-     * Returns array of constant names that should be ignored during other
-     * tests.
-     *
-     * @return array
-     */
-    protected function getConstantsToIgnore(): array
-    {
-        return [
-            'RESERVED_MIN_API_CODE_OFFSET',
-            'RESERVED_MAX_API_CODE_OFFSET',
-        ];
-    }
+	/**
+	 * Returns array of constant names that should be ignored during other
+	 * tests.
+	 *
+	 * @return array
+	 */
+	protected function getConstantsToIgnore(): array
+	{
+		return [
+			'RESERVED_MIN_API_CODE_OFFSET',
+			'RESERVED_MAX_API_CODE_OFFSET',
+		];
+	}
 
-    /**
-     * Returns array of constant names that are now turned into
-     * regular methods, so these methods will be now called
-     * by other tests.
-     *
-     * @return array
-     */
-    protected function getConstantsThatAreNowMethods(): array
-    {
-        return ['OK_OFFSET',
-                'NO_ERROR_MESSAGE_OFFSET',
-                'EX_HTTP_NOT_FOUND_OFFSET',
-                'EX_HTTP_SERVICE_UNAVAILABLE_OFFSET',
-                'EX_HTTP_EXCEPTION_OFFSET',
-                'EX_UNCAUGHT_EXCEPTION_OFFSET',
-                'EX_AUTHENTICATION_EXCEPTION_OFFSET',
-                'EX_VALIDATION_EXCEPTION_OFFSET',];
-    }
+	/**
+	 * Returns array of constant names that are now turned into
+	 * regular methods, so these methods will be now called
+	 * by other tests.
+	 *
+	 * @return array
+	 */
+	protected function getConstantsThatAreNowMethods(): array
+	{
+		return ['OK_OFFSET',
+		        'NO_ERROR_MESSAGE_OFFSET',
+		        'EX_HTTP_NOT_FOUND_OFFSET',
+		        'EX_HTTP_SERVICE_UNAVAILABLE_OFFSET',
+		        'EX_HTTP_EXCEPTION_OFFSET',
+		        'EX_UNCAUGHT_EXCEPTION_OFFSET',
+		        'EX_AUTHENTICATION_EXCEPTION_OFFSET',
+		        'EX_VALIDATION_EXCEPTION_OFFSET',];
+	}
 
-    /**
-     * Checks if Api codes range is set right
-     *
-     * @return void
-     *
-     * @noinspection PhpUnhandledExceptionInspection
-     */
-    public function testMinMaxCode(): void
-    {
-        $min = $this->callProtectedMethod(BaseApiCodes::class, 'getMinCode');
-        $this->assertNotNull($min);
+	/**
+	 * Checks if Api codes range is set right
+	 *
+	 * @return void
+	 *
+	 * @noinspection PhpUnhandledExceptionInspection
+	 */
+	public function testMinMaxCode(): void
+	{
+		$min = $this->callProtectedMethod(BaseApiCodes::class, 'getMinCode');
+		$this->assertNotNull($min);
 
-        $max = $this->callProtectedMethod(BaseApiCodes::class, 'getMaxCode');
-        $this->assertNotNull($max);
+		$max = $this->callProtectedMethod(BaseApiCodes::class, 'getMaxCode');
+		$this->assertNotNull($max);
 
-        $this->assertTrue($max > $min);
-    }
+		$this->assertTrue($max > $min);
+	}
 
-    /**
-     * Checks if defined code range is large enough to accommodate built-in codes.
-     *
-     * @return void
-     */
-    public function testCodeRangeIsLargeEnough(): void
-    {
-        $base_max = BaseApiCodes::RESERVED_MAX_API_CODE_OFFSET;
-        $min = $this->callProtectedMethod(BaseApiCodes::class, 'getMinCode');
-        $max = $this->callProtectedMethod(BaseApiCodes::class, 'getMaxCode');
+	/**
+	 * Checks if defined code range is large enough to accommodate built-in codes.
+	 *
+	 * @return void
+	 */
+	public function testCodeRangeIsLargeEnough(): void
+	{
+		$base_max = BaseApiCodes::RESERVED_MAX_API_CODE_OFFSET;
+		$min = $this->callProtectedMethod(BaseApiCodes::class, 'getMinCode');
+		$max = $this->callProtectedMethod(BaseApiCodes::class, 'getMaxCode');
 
-        $this->assertTrue(($max - $min) > $base_max);
-    }
+		$this->assertTrue(($max - $min) > $base_max);
+	}
 
-    /**
-     * Checks if all Api codes defined in ApiCodes class contain mapping entry.
-     *
-     * @return void
-     *
-     * @throws \ReflectionException
-     */
-    public function testIfAllCodesGotMapping(): void
-    {
-        $const_to_ignore = $this->getConstantsToIgnore();
-        $consts_methods = $this->getConstantsThatAreNowMethods();
+	/**
+	 * Checks if all Api codes defined in ApiCodes class contain mapping entry.
+	 *
+	 * @return void
+	 *
+	 * @throws \ReflectionException
+	 */
+	public function testIfAllCodesGotMapping(): void
+	{
+		$const_to_ignore = $this->getConstantsToIgnore();
+		$consts_methods = $this->getConstantsThatAreNowMethods();
 
-        /** @var BaseApiCodes $api_codes */
-        $api_codes = $this->getApiCodesClassName();
-        $codes = $api_codes::getApiCodeConstants();
+		/** @var BaseApiCodes $api_codes */
+		$api_codes = $this->getApiCodesClassName();
+		$codes = $api_codes::getApiCodeConstants();
 
-        foreach ($codes as $name => $val) {
-            if (\in_array($name, $const_to_ignore, true)) {
-                $this->assertTrue(true);
-                continue;
-            }
+		foreach ($codes as $name => $val) {
+			if (\in_array($name, $const_to_ignore, true)) {
+				$this->assertTrue(true);
+				continue;
+			}
 
-            if (\in_array($name, $consts_methods, true)) {
-                $name = \str_replace('_OFFSET', '', $name);
-                $val = BaseApiCodes::$name();
-            }
+			if (\in_array($name, $consts_methods, true)) {
+				$name = \str_replace('_OFFSET', '', $name);
+				$val = BaseApiCodes::$name();
+			}
 
-            $this->assertNotNull($api_codes::getCodeMessageKey($val), "No message mapping for {$name} found.");
-        }
-    }
+			$this->assertNotNull($api_codes::getCodeMessageKey($val), "No message mapping for {$name} found.");
+		}
+	}
 
-    /**
-     * Checks if all Api codes are in correct and allowed range.
-     *
-     * @return void
-     */
-    public function testIfAllCodesAreInRange(): void
-    {
-        $const_to_ignore = $this->getConstantsToIgnore();
-        $const_now_method = $this->getConstantsThatAreNowMethods();
+	/**
+	 * Checks if all Api codes are in correct and allowed range.
+	 *
+	 * @return void
+	 */
+	public function testIfAllCodesAreInRange(): void
+	{
+		$const_to_ignore = $this->getConstantsToIgnore();
+		$const_now_method = $this->getConstantsThatAreNowMethods();
 
-        /** @var BaseApiCodes $api_codes */
-        $api_codes = $this->getApiCodesClassName();
-        $codes = $api_codes::getApiCodeConstants();
-        foreach ($codes as $name => $val) {
-            if (\in_array($name, $const_to_ignore, true)) {
-                $this->assertTrue(true);
-                continue;
-            }
+		/** @var BaseApiCodes $api_codes */
+		$api_codes = $this->getApiCodesClassName();
+		$codes = $api_codes::getApiCodeConstants();
+		foreach ($codes as $name => $val) {
+			if (\in_array($name, $const_to_ignore, true)) {
+				$this->assertTrue(true);
+				continue;
+			}
 
-            if (\in_array($name, $const_now_method, true)) {
-                $name = \str_replace('_OFFSET', '', $name);
-                $val = BaseApiCodes::$name();
-            }
-            $msg = \sprintf("Value of '{$name}' ({$val}) is out of allowed range %d-%d",
-                $api_codes::getMinCode(), $api_codes::getMaxCode());
+			if (\in_array($name, $const_now_method, true)) {
+				$name = \str_replace('_OFFSET', '', $name);
+				$val = BaseApiCodes::$name();
+			}
+			$msg = \sprintf("Value of '{$name}' ({$val}) is out of allowed range %d-%d",
+				$api_codes::getMinCode(), $api_codes::getMaxCode());
 
-            $this->assertTrue($api_codes::isCodeValid($val), $msg);
-        }
-    }
+			$this->assertTrue($api_codes::isCodeValid($val), $msg);
+		}
+	}
 
-    /**
-     * Checks if all defined Api code constants' values are unique.
-     *
-     * @return void
-     */
-    public function testIfAllApiValuesAreUnique(): void
-    {
-        /** @var BaseApiCodes $api_codes_class_name */
-        $api_codes_class_name = $this->getApiCodesClassName();
-        $items = \array_count_values($api_codes_class_name::getMap());
-        foreach ($items as $code => $count) {
-            $this->assertLessThanOrEqual($count, 1, sprintf("Value of  '{$code}' is not unique. Used {$count} times."));
-        }
-    }
+	/**
+	 * Checks if all defined Api code constants' values are unique.
+	 *
+	 * @return void
+	 */
+	public function testIfAllApiValuesAreUnique(): void
+	{
+		/** @var BaseApiCodes $api_codes_class_name */
+		$api_codes_class_name = $this->getApiCodesClassName();
+		$items = \array_count_values($api_codes_class_name::getMap());
+		foreach ($items as $code => $count) {
+			$this->assertLessThanOrEqual($count, 1, sprintf("Value of  '{$code}' is not unique. Used {$count} times."));
+		}
+	}
 
-    /**
-     * Checks if all codes are mapped to existing locale strings.
-     *
-     * @return void
-     */
-    public function testIfAllCodesAreCorrectlyMapped(): void
-    {
-        /** @var BaseApiCodes $api_codes_class_name */
-        $api_codes_class_name = $this->getApiCodesClassName();
-        $map = $api_codes_class_name::getMap();
-        foreach ($map as $code => $mapping) {
-            $str = \Lang::get($mapping);
-            $this->assertNotEquals($mapping, $str,
-                \sprintf('No lang entry for: %s referenced by %s', $mapping, $this->resolveConstantFromCode($code))
-            );
-        }
-    }
+	/**
+	 * Checks if all codes are mapped to existing locale strings.
+	 *
+	 * @return void
+	 */
+	public function testIfAllCodesAreCorrectlyMapped(): void
+	{
+		/** @var BaseApiCodes $api_codes_class_name */
+		$api_codes_class_name = $this->getApiCodesClassName();
+		$map = $api_codes_class_name::getMap();
+		foreach ($map as $code => $mapping) {
+			$str = \Lang::get($mapping);
+			$this->assertNotEquals($mapping, $str,
+				\sprintf('No lang entry for: %s referenced by %s', $mapping, $this->resolveConstantFromCode($code))
+			);
+		}
+	}
 
-    /**
-     * Tests if "classes" config entries are properly set and use at least
-     * mandatory configuration elements.
-     *
-     * @return void
-     */
-    public function testConfigClassesMappingEntriesMandatoryKeys(): void
-    {
-        $classes = \Config::get(RB::CONF_KEY_CONVERTER_CLASSES) ?? [];
-        if (\count($classes) === 0) {
-            // to make PHPUnit not complaining about no assertion.
-            $this->assertTrue(true);
+	/**
+	 * Tests if "classes" config entries are properly set and use at least
+	 * mandatory configuration elements.
+	 *
+	 * @return void
+	 */
+	public function testConfigClassesMappingEntriesMandatoryKeys(): void
+	{
+		$classes = \Config::get(RB::CONF_KEY_CONVERTER_CLASSES) ?? [];
+		if (\count($classes) === 0) {
+			// to make PHPUnit not complaining about no assertion.
+			$this->assertTrue(true);
 
-            return;
-        }
+			return;
+		}
 
-        $mandatory_keys = [
-            RB::KEY_HANDLER,
-        ];
-        foreach ($classes as $class_name => $class_config) {
-            foreach ($mandatory_keys as $key_name) {
-                /** @var TestCase $this */
-                $this->assertArrayHasKey($key_name, $class_config);
-            }
-        }
-    }
+		$mandatory_keys = [
+			RB::KEY_HANDLER,
+		];
+		foreach ($classes as $class_name => $class_config) {
+			foreach ($mandatory_keys as $key_name) {
+				/** @var TestCase $this */
+				$this->assertArrayHasKey($key_name, $class_config);
+			}
+		}
+	}
 
-    /**
-     * Tests if "classes" config entries properly set, which means we look for any
-     * unknown/unsupported configuration key.
-     *
-     * @return void
-     */
-    public function testConfigClassesMappingEntriesUnwantedConfigKeys(): void
-    {
-        $classes = \Config::get(RB::CONF_KEY_CONVERTER_CLASSES, []);
-        if (\count($classes) === 0) {
-            // to make PHPUnit not complaining about no assertion.
-            $this->assertTrue(true);
+	/**
+	 * Tests if "classes" config entries properly set, which means we look for any
+	 * unknown/unsupported configuration key.
+	 *
+	 * @return void
+	 */
+	public function testConfigClassesMappingEntriesUnwantedConfigKeys(): void
+	{
+		$classes = \Config::get(RB::CONF_KEY_CONVERTER_CLASSES, []);
+		if (\count($classes) === 0) {
+			// to make PHPUnit not complaining about no assertion.
+			$this->assertTrue(true);
 
-            return;
-        }
+			return;
+		}
 
-        foreach ($classes as $class_name => $class_config) {
-            foreach ($class_config as $cfg_key => $cfg_val) {
-                switch ($cfg_key) {
-                    case RB::KEY_KEY:
-	                case RB::KEY_HANDLER:
-                        $this->assertIsString($cfg_val);
-                        $this->assertNotEmpty(trim($cfg_val));
-                        break;
-                    case RB::KEY_PRI:
-                        $this->assertIsInt($cfg_val);
-                        $this->assertIsNumeric($cfg_val);
-                        break;
-                    default:
-                        $this->fail("Unknown key '{$cfg_key}' in '{$class_name}' data conversion config.");
-                }
-            }
-        }
+		foreach ($classes as $class_name => $class_config) {
+			foreach ($class_config as $cfg_key => $cfg_val) {
+				switch ($cfg_key) {
+					case RB::KEY_KEY:
+						if (\is_string($cfg_val)) {
+							$this->assertIsString($cfg_val);
+							$this->assertNotEmpty(trim($cfg_val));
+						} elseif ($cfg_val !== null) {
+							$this->fail(
+								\sprintf("Value for key '{$cfg_key}' in '{$class_name}' must be string or null (%s found)", \gettype($cfg_key)));
+						}
+						break;
+					case RB::KEY_HANDLER:
+						$this->assertIsString($cfg_val);
+						$this->assertNotEmpty(trim($cfg_val));
+						break;
+					case RB::KEY_PRI:
+						$this->assertIsInt($cfg_val);
+						$this->assertIsNumeric($cfg_val);
+						break;
+					default:
+						$this->fail("Unknown key '{$cfg_key}' in '{$class_name}' data conversion config.");
+				}
+			}
+		}
 
-        $supported_keys = [
-            RB::KEY_KEY,
-            RB::KEY_PRI,
-            RB::KEY_HANDLER,
-        ];
-        foreach ($classes as $class_name => $class_config) {
-            foreach ($class_config as $cfg_key => $cfg_val) {
-                $msg = "Unknown key '{$cfg_key}' in '{$class_name}' data conversion config.";
-                $this->assertContains($cfg_key, $supported_keys, $msg);
-            }
-        }
-    }
+		$supported_keys = [
+			RB::KEY_KEY,
+			RB::KEY_PRI,
+			RB::KEY_HANDLER,
+		];
+		foreach ($classes as $class_name => $class_config) {
+			foreach ($class_config as $cfg_key => $cfg_val) {
+				$msg = "Unknown key '{$cfg_key}' in '{$class_name}' data conversion config.";
+				$this->assertContains($cfg_key, $supported_keys, $msg);
+			}
+		}
+	}
 
 
 } // end of ApiCodesTests trait

--- a/tests/tests/Converter/DefaultConfigTest.php
+++ b/tests/tests/Converter/DefaultConfigTest.php
@@ -24,158 +24,211 @@ use MarcinOrlowski\ResponseBuilder\Tests\Models\TestModelJsonSerializable;
 
 class DefaultConfigTest extends TestCase
 {
-    /**
-     * Tests converter behavior on default config on object implementing Laravel's Arrayable interface.
-     *
-     * @return void
-     */
-    public function testArrayable(): void
-    {
-        // GIVEN object implementing Arrayable interface
-        $obj_val = $this->getRandomString('val_1');
-        $obj = new TestModelArrayable($obj_val);
+	/**
+	 * Tests converter behavior on default config on object implementing Laravel's Arrayable interface.
+	 *
+	 * @return void
+	 */
+	public function testArrayable(): void
+	{
+		// GIVEN object implementing Arrayable interface
+		$obj_val = $this->getRandomString('val_1');
+		$obj = new TestModelArrayable($obj_val);
 
-        // HAVING converter with default settings
-        $converter = new Converter();
+		// HAVING converter with default settings
+		$converter = new Converter();
 
-        // WHEN we try to pass of object of that class
-        $result = $converter->convert($obj);
+		// WHEN we try to pass of object of that class
+		$result = $converter->convert($obj);
 
-        // THEN it should be converted automatically as per configuration
-	    $cfg = Config::get(RB::CONF_KEY_CONVERTER_CLASSES);
-	    $this->assertNotEmpty($cfg);
-	    $key = $cfg[ \Illuminate\Contracts\Support\Arrayable::class ][ RB::KEY_KEY ];
+		// THEN it should be converted automatically as per configuration
+		$cfg = Config::get(RB::CONF_KEY_CONVERTER_CLASSES);
+		$this->assertNotEmpty($cfg);
+		$key = $cfg[ \Illuminate\Contracts\Support\Arrayable::class ][ RB::KEY_KEY ];
 
-	    $this->assertIsArray($result);
-	    $this->assertArrayHasKey($key, $result);
-	    $result = $result[$key];
-        $this->assertArrayHasKey(TestModelArrayable::FIELD_NAME, $result);
-        $this->assertEquals($result[TestModelArrayable::FIELD_NAME], $obj_val);
-    }
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey($key, $result);
+		$result = $result[ $key ];
+		$this->assertArrayHasKey(TestModelArrayable::FIELD_NAME, $result);
+		$this->assertEquals($result[ TestModelArrayable::FIELD_NAME ], $obj_val);
+	}
 
-    /**
-     * Tests converter behavior on default config on object implementing JsonSerializable interface.
-     *
-     * @return void
-     */
-    public function testJsonSerializable(): void
-    {
-    	$values = [
-		    $this->getRandomString('obj_val'),
-		    [$this->getRandomString('obj_a'), $this->getRandomString('obj_b')],
-		    mt_rand(),
-    		];
+	/**
+	 * Tests converter behavior on default config on object implementing JsonSerializable interface.
+	 *
+	 * @return void
+	 */
+	public function testJsonSerializable(): void
+	{
+		$values = [
+			$this->getRandomString('obj_val'),
+			[$this->getRandomString('obj_a'),
+			 $this->getRandomString('obj_b')],
+			mt_rand(),
+		];
 
-    	foreach ($values as $obj_val) {
-	        // GIVEN JsonSerializable class object
-	        $obj = new TestModelJsonSerializable($obj_val);
+		foreach ($values as $obj_val) {
+			// GIVEN JsonSerializable class object
+			$obj = new TestModelJsonSerializable($obj_val);
 
-	        // HAVING converter with default settings
-	        $converter = new Converter();
+			// HAVING converter with default settings
+			$converter = new Converter();
 
-	        // WHEN we try to pass of object of that class
-	        $result = $converter->convert($obj);
+			// WHEN we try to pass of object of that class
+			$result = $converter->convert($obj);
 
-	        // THEN it should be converted automatically as per configuration
-		    $cfg = Config::get(RB::CONF_KEY_CONVERTER_CLASSES);
-		    $this->assertNotEmpty($cfg);
-		    $key = $cfg[ \JsonSerializable::class ][ RB::KEY_KEY ];
+			// THEN it should be converted automatically as per configuration
+			$cfg = Config::get(RB::CONF_KEY_CONVERTER_CLASSES);
+			$this->assertNotEmpty($cfg);
+			$key = $cfg[ \JsonSerializable::class ][ RB::KEY_KEY ];
 
-	        $this->assertIsArray($result);
-		    $this->assertArrayHasKey($key, $result);
-		    $result = $result[$key];
-	        $this->assertArrayHasKey($key, $result);
-	        $this->assertEquals($obj_val, $result[$key]);
-	    }
-    }
+			$this->assertIsArray($result);
+			$this->assertArrayHasKey($key, $result);
+			$result = $result[ $key ];
+			$this->assertArrayHasKey($key, $result);
+			$this->assertEquals($obj_val, $result[ $key ]);
+		}
+	}
 
-    /**
-     * Tests converter behavior on default config on object extending Laravel's JsonResource class.
-     *
-     * @return void
-     */
-    public function testJsonResource(): void
-    {
-        // GIVEN JSONResource class object
-        $obj_val = $this->getRandomString('obj_val');
-        $obj = new TestModelJsonResource($obj_val);
+	/**
+	 * Tests converter behavior on default config on object extending Laravel's JsonResource class.
+	 *
+	 * @return void
+	 */
+	public function testJsonResource(): void
+	{
+		// GIVEN JSONResource class object
+		$obj_val = $this->getRandomString('obj_val');
+		$obj = new TestModelJsonResource($obj_val);
 
-        // HAVING converter with default settings
-        $converter = new Converter();
+		// HAVING converter with default settings
+		$converter = new Converter();
 
-        // WHEN we try to pass of object of that class
-        $result = $converter->convert($obj);
+		// WHEN we try to pass of object of that class
+		$result = $converter->convert($obj);
 
-        // THEN it should be converted automatically as per configuration
-	    $cfg = Config::get(RB::CONF_KEY_CONVERTER_CLASSES);
-	    $this->assertNotEmpty($cfg);
-	    $key = $cfg[ \Illuminate\Http\Resources\Json\JsonResource::class ][ RB::KEY_KEY ];
+		// THEN it should be converted automatically as per configuration
+		$cfg = Config::get(RB::CONF_KEY_CONVERTER_CLASSES);
+		$this->assertNotEmpty($cfg);
+		$key = $cfg[ \Illuminate\Http\Resources\Json\JsonResource::class ][ RB::KEY_KEY ];
 
-        $this->assertIsArray($result);
-	    $this->assertArrayHasKey($key, $result);
-	    $result = $result[$key];
-        $this->assertArrayHasKey(TestModelJsonResource::FIELD_NAME, $result);
-        $this->assertEquals($result[TestModelJsonResource::FIELD_NAME], $obj_val);
-    }
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey($key, $result);
+		$result = $result[ $key ];
+		$this->assertArrayHasKey(TestModelJsonResource::FIELD_NAME, $result);
+		$this->assertEquals($result[ TestModelJsonResource::FIELD_NAME ], $obj_val);
+	}
 
-    /**
-     * Tests converter behavior on default config on Laravel's Support\Collection.
-     *
-     * @return void
-     */
-    public function testSupportCollection(): void
-    {
-        $data = [];
-        for ($i = 0; $i < 10; $i++) {
-            $data[] = $this->getRandomString("item{$i}");
-        }
-        $this->doCollectionTests(collect($data));
-    }
+	/**
+	 * Tests converter behavior on default config on Laravel's Support\Collection.
+	 *
+	 * @return void
+	 */
+	public function testSupportCollection(): void
+	{
+		$data = [];
+		for ($i = 0; $i < 10; $i++) {
+			$data[] = $this->getRandomString("item{$i}");
+		}
+		$this->doCollectionTests(collect($data));
+	}
 
-    /**
-     * Tests converter behavior on default config on Laravel Eloquent's Collection.
-     *
-     * @return void
-     */
-    public function testEloquentCollection(): void
-    {
-        // GIVEN Eloquent collection with content
-        $collection = new EloquentCollection();
-        $collection->add($this->getRandomString('item1'));
-        $collection->add($this->getRandomString('item2'));
-        $collection->add($this->getRandomString('item3'));
+	/**
+	 * Tests converter behavior on default config on Laravel Eloquent's Collection.
+	 *
+	 * @return void
+	 */
+	public function testEloquentCollection(): void
+	{
+		// GIVEN Eloquent collection with content
+		$collection = new EloquentCollection();
+		$collection->add($this->getRandomString('item1'));
+		$collection->add($this->getRandomString('item2'));
+		$collection->add($this->getRandomString('item3'));
 
-        $this->doCollectionTests($collection);
-    }
+		$this->doCollectionTests($collection);
+	}
 
-    // -----------------------------------------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------------------------------------
 
-    /**
-     * Helper method to perform some common tests of built-in support for Laravel's collections.
-     *
-     * @param object|array $collection
-     *
-     * @return array
-     */
-    protected function doCollectionTests($collection): array
-    {
-        // HAVING Converter with default settings
-        // WHEN we try to pass of object of that class
-        $result = (new Converter())->convert($collection);
+	/**
+	 * Checks if default config for LengthAwarePaginator class produces expected output.
+	 */
+	public function testLengthAwarePaginator(): void
+	{
+		$data = [];
+		for ($i = 0; $i < \mt_rand(10, 20); $i++) {
+			$data[] = $this->getRandomString("item{$i}");
+		}
+		$total = \count($data);
+		$this->doPaginatorSupportTests(
+			new \Illuminate\Pagination\LengthAwarePaginator(collect($data), $total, $total / 2));
+	}
 
-        // THEN it should be converted automatically as per default configuration
-	    $cfg = Config::get(RB::CONF_KEY_CONVERTER_CLASSES);
-	    $key = $cfg[ \get_class($collection) ][ RB::KEY_KEY ];
+	/**
+	 * Checks if default config for Paginator class produces expected output.
+	 */
+	public function testPaginator(): void
+	{
+		$data = [];
+		for ($i = 0; $i < \mt_rand(10, 20); $i++) {
+			$data[] = $this->getRandomString("item{$i}");
+		}
 
-	    $this->assertIsArray($result);
-	    $this->assertArrayHasKey($key, $result);
-	    $result = $result[$key];
+		$this->doPaginatorSupportTests(
+			new \Illuminate\Pagination\Paginator(collect($data), \count($data) / 2));
+	}
 
-        foreach ($collection as $key => $val) {
-            $this->assertArrayHasKey($key, $result);
-            $this->assertEquals($val, $result[ $key ]);
-        }
+	/**
+	 * Helper that performs common tests for Paginator support.
+	 *
+	 * @param object $paginator
+	 */
+	protected function doPaginatorSupportTests($paginator): void
+	{
+		$result = (new Converter())->convert($paginator);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKeys([
+			"current_page",
+			"data",
+			"first_page_url",
+			"from",
+			"next_page_url",
+			"path",
+			"per_page",
+			"prev_page_url",
+			"to",
+		], $result);
+	}
 
-        return $result;
-    }
+	// -----------------------------------------------------------------------------------------------------------
+
+	/**
+	 * Helper method to perform some common tests of built-in support for Laravel's collections.
+	 *
+	 * @param object|array $collection
+	 *
+	 * @return array
+	 */
+	protected function doCollectionTests($collection): array
+	{
+		// HAVING Converter with default settings
+		// WHEN we try to pass of object of that class
+		$result = (new Converter())->convert($collection);
+
+		// THEN it should be converted automatically as per default configuration
+		$cfg = Config::get(RB::CONF_KEY_CONVERTER_CLASSES);
+		$key = $cfg[ \get_class($collection) ][ RB::KEY_KEY ];
+
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey($key, $result);
+		$result = $result[ $key ];
+
+		foreach ($collection as $key => $val) {
+			$this->assertArrayHasKey($key, $result);
+			$this->assertEquals($val, $result[ $key ]);
+		}
+
+		return $result;
+	}
 }


### PR DESCRIPTION
   * `Paginator` and `LengthAwarePaginator` support is now included in default converter  configuration (reported by @kcaj-burr) (Fixes #175)
   * Fixed `testConfigClassesMappingEntriesUnwantedConfigKeys()` testing trait not supporting `null` keys in converter config.