### PR TITLE
Release v9.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "marcin-orlowski/laravel-api-response-builder",
   "description": "Helps building nice, normalized and easy to consume Laravel REST API.",
   "homepage": "https://github.com/MarcinOrlowski/laravel-api-response-builder",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "keywords": [
     "laravel",
     "json",

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -8,6 +8,10 @@
 
 ## CHANGE LOG ##
 
+* v9.2.3 (2021-04-21)
+  * [RB-194] Changed signature of ExceptionHandlers' `handle()` method to expectc `Throwable`
+    instead of `Exception` (reported by @genesiscz).
+
 * v9.2.2 (2021-03-05)
    * [RB-190] Fixed converting resource and resource collection (reported by @achinkumar121).
 

--- a/src/Contracts/ExceptionHandlerContract.php
+++ b/src/Contracts/ExceptionHandlerContract.php
@@ -32,10 +32,10 @@ interface ExceptionHandlerContract
 	 *                  `msg_key` is set, or message referenced by `msg_key` completely ignoring exception
 	 *                  message ($ex->getMessage()).
 	 *
-	 * @param array      $config Config array (can be empty) with any keys required by given handle.
-	 * @param \Exception $ex     The exception to handle.
+	 * @param array      $user_config Config array (can be empty) with any keys required by given handle.
+	 * @param \Throwable $ex          The throwable to handle.
 	 *
 	 * @return array|null
 	 */
-	public function handle(array $config, \Exception $ex): ?array;
+	public function handle(array $user_config, \Throwable $ex): ?array;
 }

--- a/src/ExceptionHandlers/DefaultExceptionHandler.php
+++ b/src/ExceptionHandlers/DefaultExceptionHandler.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response as HttpResponse;
  */
 final class DefaultExceptionHandler implements ExceptionHandlerContract
 {
-	public function handle(array $user_config, /** @scrutinizer ignore-unused */ \Exception $ex): ?array
+	public function handle(array $user_config, /** @scrutinizer ignore-unused */ \Throwable $ex): ?array
 	{
 		$defaults = [
 			RB::KEY_API_CODE  => BaseApiCodes::EX_UNCAUGHT_EXCEPTION(),

--- a/src/ExceptionHandlers/HttpExceptionHandler.php
+++ b/src/ExceptionHandlers/HttpExceptionHandler.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response as HttpResponse;
  */
 final class HttpExceptionHandler implements ExceptionHandlerContract
 {
-	public function handle(array $user_config, \Exception $ex): ?array
+	public function handle(array $user_config, \Throwable $ex): ?array
 	{
 		$default_config = [
 			// used by unauthenticated() to obtain api and http code for the exception

--- a/src/ExceptionHandlers/ValidationExceptionHandler.php
+++ b/src/ExceptionHandlers/ValidationExceptionHandler.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response as HttpResponse;
  */
 final class ValidationExceptionHandler implements ExceptionHandlerContract
 {
-	public function handle(array $user_config, /** @scrutinizer ignore-unused */ \Exception $ex): ?array
+	public function handle(array $user_config, /** @scrutinizer ignore-unused */ \Throwable $ex): ?array
 	{
 		return [
 			RB::KEY_API_CODE  => BaseApiCodes::EX_VALIDATION_EXCEPTION(),


### PR DESCRIPTION
* Changed signature of ExceptionHandlers' `handle()` method to expectc `Throwable` instead of `Exception`. Fixes #194 