### PR TITLE
Fix Syntax - Handler Registeration .md

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -49,7 +49,7 @@ use MarcinOrlowski\ResponseBuilder\ExceptionHandlerHelper;
 public function register()
 {
     $this->renderable(function (Throwable $ex, $request) {
-        return ExceptionHandlerHelper::handle($ex, $request);
+        return ExceptionHandlerHelper::render($request ,$ex );
     });
 }
 ```


### PR DESCRIPTION
There is no handle function in ExceptionHandlerHelper and we have to use render function instead, On the other hands the Parameters is not passed in the right order.

# This pull request... #

* [ ] Closes #TICKET-NUMBER

## Checklist: ##

* [ ] I have opened the issue ticket that this pull request is part of.
* [ ] This pull request title contains `(#TICKET-NUMBER)` for reference.
* [ ] This pull request description contains `Closes #{$ISSUE_NO}` that closes ticket.
* [ ] This pull request is all my own work - I have not plagiarized.
* [ ] This contribution is licensed under MIT or compatible license.
* [ ] All code is covered in unit tests and all tests pass.
* [ ] I have updated the docs to cover my changes (if applicable).
* [ ] All function parameters and return values are annotated with PHP [type hints](https://www.php.net/manual/en/language.oop5.typehinting.php).
* [ ] All functions have [PHPDocs](https://docs.phpdoc.org/3.0/guide/references/phpdoc/index.html) blocks.

