### PR TITLE
Add and document semantic response builders with tests

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -12,6 +12,7 @@
 * [Handling Exceptions API way](#handling-exceptions-api-way)
 * [Overriding code to message conversion](#overriding-code-to-message-conversion)
 * [Overriding built-in messages](#overriding-built-in-messages)
+* [Semantic Response Builders](#semantic-response-builders)
 
 ---
 
@@ -160,3 +161,46 @@ MarcinOrlowski\ResponseBuilder\BaseApiCodes::NO_ERROR_MESSAGE() => 'my_messages.
 
 You can use `:api_code` placeholder in the message and it will be substituted actual error code
 value.
+
+# Semantic Response Builders #
+
+This fork also provides semantic builder starter methods for common HTTP success and error
+responses. These methods are convenience wrappers over `asSuccess()` and `asError()` and preset the
+HTTP status code for standard cases.
+
+For example, instead of writing:
+
+```php
+return RB::asSuccess()
+    ->withData($data)
+    ->withHttpCode(HttpResponse::HTTP_CREATED)
+    ->build();
+```
+
+you can write:
+
+```php
+return SuccessResponseBuilder::asCreated()
+    ->withData($data)
+    ->build();
+```
+
+Likewise, instead of writing:
+
+```php
+return RB::asError(ApiCode::AUTHENTICATION_EXCEPTION)
+    ->withMessage(__('auths.failures.invalid_token'))
+    ->withHttpCode(HttpResponse::HTTP_UNAUTHORIZED)
+    ->build();
+```
+
+```php
+return FailureResponseBuilder::asUnauthorized()
+    ->withMessage(__('auths.failures.invalid_token'))
+    ->build();
+```
+
+Semantic builder methods preset and lock the HTTP status code. Calling withHttpCode() after one of
+these methods is not allowed and will result in exception.
+
+

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -6,7 +6,9 @@
 
 * [Usage examples](#examples)
   * [Success](#success)
+	* [Success with semantic builders](#success-with-semantic-builders)
   * [Errors](#errors)
+    * [Errors with semantic builders](#errors-with-semantic-builders)
 
 ---
 
@@ -128,6 +130,40 @@ and your client will get that data in `data` node of your response:
 You can easily add own converters if none of built-in handles your data or fits your needs!
 See [Data Conversion](conversion.md) for more details.
 
+### Success with semantic builders ###
+
+Semantic success builders for common HTTP success responses are also provided. These methods
+preset and lock the HTTP status code, so there is no need to call `withHttpCode()` manually for
+standard cases.
+
+For example, instead of:
+
+```php
+return RB::asSuccess()
+    ->withData($data)
+    ->withHttpCode(HttpResponse::HTTP_OK)
+    ->build();
+```
+
+you can now write:
+
+```php
+return SuccessResponseBuilder::asOk()
+    ->withData($data)
+    ->build();
+```
+
+To return 201 Created:
+
+```php
+return SuccessResponseBuilder::asCreated()
+    ->withData($data)
+    ->build();
+```
+
+> ![WARNING](img/warning.png) Semantic builder methods preset and lock the HTTP status code.
+Calling withHttpCode() after one of these methods is not allowed and will result in exception.
+
 ## Errors ##
 
 Returning error responses is also simple, however in such case you are required to need to
@@ -188,3 +224,37 @@ to handle them yourself by calling `Lang::get()` manually first and pass the res
 $msg = Lang::get('message.something_wrong', ['login' => $login]);
 return RB::errorWithMessage(ApiCodeBase::SOMETHING_WENT_WRONG, $msg);
 ```
+
+### Errors with semantic builders ###
+
+Semantic failure builders for common HTTP error responses are also provided. These methods
+preset and lock the HTTP status code, so there is no need to call `withHttpCode()` manually for
+standard cases.
+
+For example, instead of:
+
+```php
+return RB::asError(ApiCode::AUTHENTICATION_EXCEPTION)
+    ->withMessage(__('auths.failures.invalid_token'))
+    ->withHttpCode(HttpResponse::HTTP_UNAUTHORIZED)
+    ->build();
+```
+
+you can now write:
+
+```php
+return FailureResponseBuilder::asUnauthorized()
+    ->withMessage(__('auths.failures.invalid_token'))
+    ->build();
+```
+
+To return 403 Forbidden:
+
+```php
+return FailureResponseBuilder::asForbidden()
+    ->withMessage(__('messages.failures.forbidden'))
+    ->build();
+```
+
+> ![WARNING](img/warning.png) Semantic builder methods preset and lock the HTTP status code.
+Calling withHttpCode() after one of these methods is not allowed and will result in exception.

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -7,6 +7,7 @@
 * [Exposed Methods](methods.md)
   * [Builder](#builder)
     * [Static builder methods](#builder-static)
+    * [Semantic builder methods](#semantic-builder-methods)
   * [Helpers](#helpers)
 
 ---
@@ -55,6 +56,8 @@ Parameter setters:
   `\InvalidArgumentException` will be thrown. HTTP codes from 3xx pool (redirection) are not
   allowed. Please see [W3 specification](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
   for more information about all HTTP codes and their meaning.
+  If HTTP status code was preset by a semantic builder method, calling `withHttpCode()` again is not
+  allowed and will result in exception.
 * `withData($data)`: (**mixed**) data you want to be returned in your response in `data` node,
 * `withJsonOptions($opts)`: (**int**) data-to-json conversion options
   as   [documented](http://php.net/manual/en/function.json-encode.php). Pass `null` for default
@@ -79,6 +82,38 @@ Once all the arguments are passed, call `build()` to have final `HttpResponse` o
 > object and result is returned instead. Several classes pre-configured but you can add additional
 > classes just by creating entry in configuration `converter` mapping.
 > See [Data Conversion](conversion.md) for more information.
+
+### Semantic builder methods ###
+
+This fork also provides semantic builder starter methods for common HTTP success and error
+responses. These methods are convenience wrappers over `asSuccess()` and `asError()` and preset the
+HTTP status code for standard cases.
+
+Success builders:
+
+* `SuccessResponseBuilder::asOk($api_code = null)`: Returns Builder instance configured as success
+  response with `200 OK`.
+* `SuccessResponseBuilder::asCreated($api_code = null)`: Returns Builder instance configured as
+  success response with `201 Created`.
+* `SuccessResponseBuilder::asAccepted($api_code = null)`: Returns Builder instance configured as
+  success response with `202 Accepted`.
+
+Failure builders:
+
+* `FailureResponseBuilder::asInternalServerError($api_code = null)`: Returns Builder instance configured as error response with `500 Internal Server Error`.
+* `FailureResponseBuilder::asUnauthorized($api_code = null)`: Returns Builder instance configured as error
+  response with `401 Unauthorized`.
+* `FailureResponseBuilder::asForbidden($api_code = null)`: Returns Builder instance configured as error
+  response with `403 Forbidden`.
+* `FailureResponseBuilder::asNotFound($api_code = null)`: Returns Builder instance configured as error
+  response with `404 Not Found`.
+* `FailureResponseBuilder::asTooManyRequests($api_code = null)`: Returns Builder instance configured as
+  error response with `429 Too Many Requests`.
+* `FailureResponseBuilder::asUnprocessableEntity($api_code = null)`: Returns Builder instance configured as
+  error response with `422 Unprocessable Entity`.
+
+These semantic builder methods preset and lock the HTTP status code. Calling `withHttpCode()` after
+one of these methods is not allowed and will result in exception.
 
 ## Helpers ##
 

--- a/src/Exceptions/HttpCodeLockedException.php
+++ b/src/Exceptions/HttpCodeLockedException.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace MarcinOrlowski\ResponseBuilder\Exceptions;
+
+/**
+ * Laravel API Response Builder
+ *
+ * @author    Marcin Orlowski <mail (#) marcinOrlowski (.) com>
+ * @copyright 2016-2026 Marcin Orlowski
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      https://github.com/MarcinOrlowski/laravel-api-response-builder
+ */
+final class HttpCodeLockedException extends \Exception
+{
+	// empty
+}

--- a/src/FailureResponseBuilder.php
+++ b/src/FailureResponseBuilder.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcinOrlowski\ResponseBuilder;
+
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+/**
+ * Builds semantically named error responses with preset HTTP status codes.
+ */
+class FailureResponseBuilder extends ResponseBuilder
+{
+	/**
+	 * Returns an error response builder with HTTP 403 Forbidden status code.
+	 *
+	 * If no API code is provided, authentication exception API code is used.
+	 *
+	 * @param int|null $api_code API code to be returned or @null to use
+	 *                           BaseApiCodes::EX_AUTHENTICATION_EXCEPTION().
+	 *
+	 * @throws Ex\MissingConfigurationKeyException
+	 * @throws Ex\NotIntegerException
+	 * @throws Ex\InvalidTypeException
+	 */
+	public static function asForbidden(?int $api_code = null): self
+	{
+		return static::asError($api_code ?? BaseApiCodes::EX_AUTHENTICATION_EXCEPTION())
+			->withPresetHttpCode(HttpResponse::HTTP_FORBIDDEN);
+	}
+
+	/**
+	 * Returns an error response builder with HTTP 500 Internal Server Error status code.
+	 *
+	 * If no API code is provided, generic HTTP exception API code is used.
+	 *
+	 * @param int|null $api_code API code to be returned or @null to use
+	 *                           BaseApiCodes::EX_HTTP_EXCEPTION().
+	 *
+	 * @throws Ex\MissingConfigurationKeyException
+	 * @throws Ex\NotIntegerException
+	 * @throws Ex\InvalidTypeException
+	 */
+	public static function asInternalServerError(?int $api_code = null): self
+	{
+		return static::asError($api_code ?? BaseApiCodes::EX_HTTP_EXCEPTION())
+			->withPresetHttpCode(HttpResponse::HTTP_INTERNAL_SERVER_ERROR);
+	}
+
+	/**
+	 * Returns an error response builder with HTTP 404 Not Found status code.
+	 *
+	 * If no API code is provided, not found exception API code is used.
+	 *
+	 * @param int|null $api_code API code to be returned or @null to use
+	 *                           BaseApiCodes::EX_HTTP_NOT_FOUND().
+	 *
+	 * @throws Ex\MissingConfigurationKeyException
+	 * @throws Ex\NotIntegerException
+	 * @throws Ex\InvalidTypeException
+	 */
+	public static function asNotFound(?int $api_code = null): self
+	{
+		return static::asError($api_code ?? BaseApiCodes::EX_HTTP_NOT_FOUND())
+			->withPresetHttpCode(HttpResponse::HTTP_NOT_FOUND);
+	}
+
+	/**
+	 * Returns an error response builder with HTTP 429 Too Many Requests status code.
+	 *
+	 * If no API code is provided, service unavailable exception API code is used.
+	 *
+	 * @param int|null $api_code API code to be returned or @null to use
+	 *                           BaseApiCodes::EX_HTTP_SERVICE_UNAVAILABLE().
+	 *
+	 * @throws Ex\MissingConfigurationKeyException
+	 * @throws Ex\NotIntegerException
+	 * @throws Ex\InvalidTypeException
+	 */
+	public static function asTooManyRequests(?int $api_code = null): self
+	{
+		return static::asError($api_code ?? BaseApiCodes::EX_HTTP_SERVICE_UNAVAILABLE())
+			->withPresetHttpCode(HttpResponse::HTTP_TOO_MANY_REQUESTS);
+	}
+
+	/**
+	 * Returns an error response builder with HTTP 401 Unauthorized status code.
+	 *
+	 * If no API code is provided, authentication exception API code is used.
+	 *
+	 * @param int|null $api_code API code to be returned or @null to use
+	 *                           BaseApiCodes::EX_AUTHENTICATION_EXCEPTION().
+	 *
+	 * @throws Ex\MissingConfigurationKeyException
+	 * @throws Ex\NotIntegerException
+	 * @throws Ex\InvalidTypeException
+	 */
+	public static function asUnauthorized(?int $api_code = null): self
+	{
+		return static::asError($api_code ?? BaseApiCodes::EX_AUTHENTICATION_EXCEPTION())
+			->withPresetHttpCode(HttpResponse::HTTP_UNAUTHORIZED);
+	}
+
+	/**
+	 * Returns an error response builder with HTTP 422 Unprocessable Entity status code.
+	 *
+	 * If no API code is provided, validation exception API code is used.
+	 *
+	 * @param int|null $api_code API code to be returned or @null to use
+	 *                           BaseApiCodes::EX_VALIDATION_EXCEPTION().
+	 *
+	 * @throws Ex\MissingConfigurationKeyException
+	 * @throws Ex\NotIntegerException
+	 * @throws Ex\InvalidTypeException
+	 */
+	public static function asUnprocessableEntity(?int $api_code = null): self
+	{
+		return static::asError($api_code ?? BaseApiCodes::EX_VALIDATION_EXCEPTION())
+			->withPresetHttpCode(HttpResponse::HTTP_UNPROCESSABLE_ENTITY);
+	}
+}

--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -28,6 +28,7 @@ class ResponseBuilder extends ResponseBuilderBase
     protected bool    $success   = false;
     protected int     $api_code;
     protected ?int    $http_code = null;
+	protected bool $http_code_was_preset = false;
     protected ?string $message   = null;
     /** @var array<string, mixed>|null */
     protected ?array $placeholders = null;
@@ -169,21 +170,54 @@ class ResponseBuilder extends ResponseBuilderBase
         return new static(false, $api_code);
     }
 
-    /**
-     * @param int|null $http_code
-     *
-     * @throws Ex\InvalidTypeException
-     */
-    public function withHttpCode(?int $http_code = null): self
-    {
-        Validator::assertIsType('http_code', $http_code, [
-            Type::INTEGER,
-            Type::NULL,
-        ]);
-        $this->http_code = $http_code;
+	/**
+	 * Sets HTTP status code.
+	 *
+	 * @param int|null $http_code HTTP code to be used for HttpResponse sent or @null
+	 *                            to use default value.
+	 *
+	 * @throws Ex\InvalidTypeException
+	 * @throws Ex\HttpCodeLockedException If HTTP code was already preset and cannot be overridden.
+	 */
+	public function withHttpCode(?int $http_code = null): self
+	{
+		if ($this->http_code_was_preset) {
+			throw new Ex\HttpCodeLockedException(
+				'HTTP code is locked for this response builder instance and was set to ' . $this->http_code . '.'
+			);
+		}
 
-        return $this;
-    }
+		Validator::assertIsType('http_code', $http_code, [
+			Type::INTEGER,
+			Type::NULL,
+		]);
+
+		$this->http_code = $http_code;
+
+		return $this;
+	}
+
+	/**
+	 * Sets HTTP status code and marks it as preset.
+	 *
+	 * Preset HTTP code cannot be later overridden by methods that only set
+	 * non-preset status codes.
+	 *
+	 * @param int $http_code HTTP status code to be used for the response.
+	 *
+	 * @throws Ex\InvalidTypeException
+	 */
+	protected function withPresetHttpCode(int $http_code): self
+	{
+		Validator::assertIsType('http_code', $http_code, [
+			Type::INTEGER,
+		]);
+
+		$this->http_code = $http_code;
+		$this->http_code_was_preset = true;
+
+		return $this;
+	}
 
     /**
      * @param mixed|null $data

--- a/src/SuccessResponseBuilder.php
+++ b/src/SuccessResponseBuilder.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcinOrlowski\ResponseBuilder;
+
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+/**
+ * Builds semantically named success responses with preset HTTP status codes.
+ */
+class SuccessResponseBuilder extends ResponseBuilder
+{
+	/**
+	 * Returns a success response builder with HTTP 202 Accepted status code.
+	 *
+	 * @param int|null $api_code API code to be returned or @null to use the default success API code.
+	 *
+	 * @throws Ex\MissingConfigurationKeyException
+	 * @throws Ex\NotIntegerException
+	 * @throws Ex\InvalidTypeException
+	 */
+	public static function asAccepted(?int $api_code = null): self
+	{
+		return static::asSuccess($api_code)
+			->withPresetHttpCode(HttpResponse::HTTP_ACCEPTED);
+	}
+
+	/**
+	 * Returns a success response builder with HTTP 201 Created status code.
+	 *
+	 * @param int|null $api_code API code to be returned or @null to use the default success API code.
+	 *
+	 * @throws Ex\MissingConfigurationKeyException
+	 * @throws Ex\NotIntegerException
+	 * @throws Ex\InvalidTypeException
+	 */
+	public static function asCreated(?int $api_code = null): self
+	{
+		return static::asSuccess($api_code)
+			->withPresetHttpCode(HttpResponse::HTTP_CREATED);
+	}
+
+	/**
+	 * Returns a success response builder with HTTP 200 OK status code.
+	 *
+	 * @param int|null $api_code API code to be returned or @null to use the default success API code.
+	 *
+	 * @throws Ex\MissingConfigurationKeyException
+	 * @throws Ex\NotIntegerException
+	 * @throws Ex\InvalidTypeException
+	 */
+	public static function asOk(?int $api_code = null): self
+	{
+		return static::asSuccess($api_code)
+			->withPresetHttpCode(HttpResponse::HTTP_OK);
+	}
+}

--- a/tests/phpunit/Builder/SemanticResponseBuilderTest.php
+++ b/tests/phpunit/Builder/SemanticResponseBuilderTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+declare(strict_types=1);
+
+namespace MarcinOrlowski\ResponseBuilder\Tests\Builder;
+
+/**
+ * Laravel API Response Builder
+ *
+ * @author    Marcin Orlowski <mail (#) marcinOrlowski (.) com>
+ * @copyright 2016-2026 Marcin Orlowski
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      https://github.com/MarcinOrlowski/laravel-api-response-builder
+ */
+
+use MarcinOrlowski\ResponseBuilder\BaseApiCodes;
+use MarcinOrlowski\ResponseBuilder\Ex\LogicException;
+use MarcinOrlowski\ResponseBuilder\Exceptions\HttpCodeLockedException;
+use MarcinOrlowski\ResponseBuilder\FailureResponseBuilder;
+use MarcinOrlowski\ResponseBuilder\SuccessResponseBuilder;
+use MarcinOrlowski\ResponseBuilder\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+/**
+ * Class SemanticResponseBuilderTest
+ */
+class SemanticResponseBuilderTest extends TestCase
+{
+	/**
+	 * Checks if asAccepted() uses HTTP 202.
+	 */
+	public function testAsAccepted(): void
+	{
+		$this->response = SuccessResponseBuilder::asAccepted()->build();
+
+		$this->assertEquals(HttpResponse::HTTP_ACCEPTED, $this->response->getStatusCode());
+
+		$api = $this->getResponseSuccessObject(expected_http_code: HttpResponse::HTTP_ACCEPTED);
+		
+		$this->assertNull($api->getData());
+		$msg_key = BaseApiCodes::getCodeMessageKey(BaseApiCodes::OK());
+		/** @var string $msg_key */
+		$this->assertEquals($this->langGet($msg_key), $api->getMessage());
+		
+	}
+
+	/**
+	 * Checks if asCreated() uses HTTP 201.
+	 */
+	public function testAsCreated(): void
+	{
+		$this->response = SuccessResponseBuilder::asCreated()->build();
+
+		$this->assertEquals(HttpResponse::HTTP_CREATED, $this->response->getStatusCode());
+
+		$api = $this->getResponseSuccessObject(expected_http_code: HttpResponse::HTTP_CREATED);
+		$this->assertNull($api->getData());
+		$msg_key = BaseApiCodes::getCodeMessageKey(BaseApiCodes::OK());
+		/** @var string $msg_key */
+		$this->assertEquals($this->langGet($msg_key), $api->getMessage());
+	}
+
+	/**
+	 * Checks if asOk() uses HTTP 200.
+	 */
+	public function testAsOk(): void
+	{
+		$this->response = SuccessResponseBuilder::asOk()->build();
+
+		$this->assertEquals(HttpResponse::HTTP_OK, $this->response->getStatusCode());
+
+		$api = $this->getResponseSuccessObject(expected_http_code: HttpResponse::HTTP_OK);
+		$this->assertNull($api->getData());
+		$msg_key = BaseApiCodes::getCodeMessageKey(BaseApiCodes::OK());
+		/** @var string $msg_key */
+		$this->assertEquals($this->langGet($msg_key), $api->getMessage());
+	}
+
+	/**
+	 * Checks if asForbidden() uses HTTP 403 and default API code.
+	 */
+	public function testAsForbidden(): void
+	{
+		$this->response = FailureResponseBuilder::asForbidden()->build();
+
+		$this->assertEquals(HttpResponse::HTTP_FORBIDDEN, $this->response->getStatusCode());
+	}
+
+	/**
+	 * Checks if asForbidden() uses custom API code if provided.
+	 */
+	public function testAsForbiddenWithCustomApiCode(): void
+	{
+		$api_code = BaseApiCodes::EX_HTTP_EXCEPTION();
+
+		$this->response = FailureResponseBuilder::asForbidden($api_code)->build();
+
+		$this->assertEquals(HttpResponse::HTTP_FORBIDDEN, $this->response->getStatusCode());
+
+		$api = $this->getResponseErrorObject(BaseApiCodes::EX_HTTP_EXCEPTION(), HttpResponse::HTTP_FORBIDDEN);
+		$this->assertNull($api->getData());
+		$msg_key = BaseApiCodes::getCodeMessageKey($api_code);
+		/** @var string $msg_key */
+		$this->assertEquals($this->langGet($msg_key), $api->getMessage());
+	}
+
+	/**
+	 * Checks if asInternalServerError() uses HTTP 500 and default API code.
+	 */
+	public function testAsInternalServerError(): void
+	{
+		$this->response = FailureResponseBuilder::asInternalServerError()->build();
+
+		$this->assertEquals(HttpResponse::HTTP_INTERNAL_SERVER_ERROR, $this->response->getStatusCode());
+	}
+
+	/**
+	 * Checks if asNotFound() uses HTTP 404 and default API code.
+	 */
+	public function testAsNotFound(): void
+	{
+		$this->response = FailureResponseBuilder::asNotFound()->build();
+
+		$this->assertEquals(HttpResponse::HTTP_NOT_FOUND, $this->response->getStatusCode());
+	}
+
+	/**
+	 * Checks if asTooManyRequests() uses HTTP 429 and default API code.
+	 */
+	public function testAsTooManyRequests(): void
+	{
+		$this->response = FailureResponseBuilder::asTooManyRequests()->build();
+
+		$this->assertEquals(HttpResponse::HTTP_TOO_MANY_REQUESTS, $this->response->getStatusCode());
+	}
+
+	/**
+	 * Checks if asUnauthorized() uses HTTP 401 and default API code.
+	 */
+	public function testAsUnauthorized(): void
+	{
+		$this->response = FailureResponseBuilder::asUnauthorized()->build();
+
+		$this->assertEquals(HttpResponse::HTTP_UNAUTHORIZED, $this->response->getStatusCode());
+	}
+
+	/**
+	 * Checks if asUnprocessableEntity() uses HTTP 422 and default API code.
+	 */
+	public function testAsUnprocessableEntity(): void
+	{
+		$this->response = FailureResponseBuilder::asUnprocessableEntity()->build();
+
+		$this->assertEquals(HttpResponse::HTTP_UNPROCESSABLE_ENTITY, $this->response->getStatusCode());
+	}
+
+	/**
+	 * Checks if preset HTTP code cannot be overridden.
+	 */
+	public function testPresetHttpCodeCannotBeOverridden(): void
+	{
+		$this->expectException(HttpCodeLockedException::class);
+
+		SuccessResponseBuilder::asOk()
+			->withHttpCode(HttpResponse::HTTP_CREATED)
+			->build();
+	}
+} // end of class


### PR DESCRIPTION
# This pull request... #

* [ ] Closes #TICKET-NUMBER
* Adds semantic success and failure response builder methods with preset HTTP status codes.
* Adds tests for the new semantic response builder methods.
* Updates documentation for the new builder methods and preset HTTP code behavior.

## Checklist: ##

* [ ] I have opened the issue ticket that this pull request is part of.
* [x] This pull request is all my own work - I have not plagiarized.
* [x] This contribution is licensed under MIT or compatible license.
* [x] I have updated the docs to cover my changes (if applicable).