### PR TITLE
Allow installation on Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
   },
   "require": {
     "php": "^8.2|^8.3|^8.4|^8.5",
-    "laravel/framework": "^12.0"
+    "laravel/framework": "^12.0|^13.0"
   },
   "require-dev": {
     "marcin-orlowski/phpunit-extra-asserts": "^5.1.0",


### PR DESCRIPTION
## Summary

Widens the framework constraint to allow installation on Laravel 13:

```diff
-    "laravel/framework": "^12.0"
+    "laravel/framework": "^12.0|^13.0"
```

## Context

We run this package in a production Laravel app that is being upgraded to Laravel 13 (13.20). The only blocker was the composer constraint — with the constraint widened, the package installs and works without any code changes:

- the full application test suite areas touching ResponseBuilder pass unchanged on 13.20
- no deprecation notices from the package under Laravel 13
- PHP 8.5 (already allowed by the `php` constraint) works as well

Happy to adjust if you'd prefer a different constraint form (e.g. `>=12.0 <14.0`) or want CI matrix entries for Laravel 13 added in this PR too.
